### PR TITLE
fix: Include day of the week in RJ time context

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -963,7 +963,6 @@
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
             "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
             "dev": true,
-            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -988,7 +987,6 @@
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
             "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.3",
                 "fast-uri": "^3.0.1",
@@ -1091,7 +1089,6 @@
                     "url": "https://github.com/sponsors/ai"
                 }
             ],
-            "peer": true,
             "dependencies": {
                 "baseline-browser-mapping": "^2.9.0",
                 "caniuse-lite": "^1.0.30001759",
@@ -2700,7 +2697,6 @@
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
             "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
             "dev": true,
-            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -2762,7 +2758,6 @@
             "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.103.0.tgz",
             "integrity": "sha512-HU1JOuV1OavsZ+mfigY0j8d1TgQgbZ6M+J75zDkpEAwYeXjWSqrGJtgnPblJjd/mAyTNQ7ygw0MiKOn6etz8yw==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "@types/eslint-scope": "^3.7.7",
                 "@types/estree": "^1.0.8",
@@ -2811,7 +2806,6 @@
             "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-5.1.4.tgz",
             "integrity": "sha512-pIDJHIEI9LR0yxHXQ+Qh95k2EvXpWzZ5l+d+jIo+RdSm9MiHfzazIxwwni/p7+x4eJZuvG1AJwgC4TNQ7NRgsg==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "@discoveryjs/json-ext": "^0.5.0",
                 "@webpack-cli/configtest": "^2.1.1",
@@ -3517,8 +3511,7 @@
             "version": "8.15.0",
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
             "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
-            "dev": true,
-            "peer": true
+            "dev": true
         },
         "acorn-import-phases": {
             "version": "1.0.4",
@@ -3532,7 +3525,6 @@
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
             "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
             "dev": true,
-            "peer": true,
             "requires": {
                 "fast-deep-equal": "^3.1.3",
                 "fast-uri": "^3.0.1",
@@ -3592,7 +3584,6 @@
             "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
             "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
             "dev": true,
-            "peer": true,
             "requires": {
                 "baseline-browser-mapping": "^2.9.0",
                 "caniuse-lite": "^1.0.30001759",
@@ -4688,8 +4679,7 @@
             "version": "5.9.3",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
             "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-            "dev": true,
-            "peer": true
+            "dev": true
         },
         "undici-types": {
             "version": "7.16.0",
@@ -4721,7 +4711,6 @@
             "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.103.0.tgz",
             "integrity": "sha512-HU1JOuV1OavsZ+mfigY0j8d1TgQgbZ6M+J75zDkpEAwYeXjWSqrGJtgnPblJjd/mAyTNQ7ygw0MiKOn6etz8yw==",
             "dev": true,
-            "peer": true,
             "requires": {
                 "@types/eslint-scope": "^3.7.7",
                 "@types/estree": "^1.0.8",
@@ -4755,7 +4744,6 @@
             "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-5.1.4.tgz",
             "integrity": "sha512-pIDJHIEI9LR0yxHXQ+Qh95k2EvXpWzZ5l+d+jIo+RdSm9MiHfzazIxwwni/p7+x4eJZuvG1AJwgC4TNQ7NRgsg==",
             "dev": true,
-            "peer": true,
             "requires": {
                 "@discoveryjs/json-ext": "^0.5.0",
                 "@webpack-cli/configtest": "^2.1.1",

--- a/src/background/background.ts
+++ b/src/background/background.ts
@@ -153,6 +153,7 @@ chrome.runtime.onMessage.addListener(
       } = message.payload;
       // Pass currentTime here as well in case cache missed and we need it now
       const currentTime = new Date().toLocaleTimeString([], {
+        weekday: "long",
         hour: "2-digit",
         minute: "2-digit",
       });

--- a/src/content/content.ts
+++ b/src/content/content.ts
@@ -370,6 +370,7 @@ function performPrefetch(
       newSongTitle: uSong.title,
       newArtist: uSong.artist,
       currentTime: new Date().toLocaleTimeString([], {
+        weekday: "long",
         hour: "2-digit",
         minute: "2-digit",
       }),


### PR DESCRIPTION
The user reported that the RJ (Radio Jockey) only receives the current time in its context and not the actual day of the week. This PR fixes the issue by updating the `currentTime` generation in both `src/content/content.ts` and `src/background/background.ts`. The `toLocaleTimeString` call now includes the `weekday: "long"` option, ensuring the context string contains the day (e.g., "Monday 9:18 PM"). This provides the RJ with the necessary context to mention the current day if relevant.

---
*PR created automatically by Jules for task [16260700081526661537](https://jules.google.com/task/16260700081526661537) started by @WinterSoldier13*