### PR TITLE
Feature: Add Google Search grounding for weather and news in DJ Intros

### DIFF
--- a/src/background/background.ts
+++ b/src/background/background.ts
@@ -18,6 +18,7 @@ export async function generateRJIntro(
   newSongTitle: string,
   newArtist: string,
   currentTime?: string,
+  cityName?: string,
   allowGeneration: boolean = true,
 ): Promise<string> {
   const key = getCacheKey(oldSongTitle, newSongTitle);
@@ -56,10 +57,12 @@ export async function generateRJIntro(
         "modelProvider",
         "geminiApiKey",
         "localServerPort",
+        "cityName",
       ]);
       const modelProvider = settings.modelProvider || "gemini-api";
       const geminiApiKey = settings.geminiApiKey || "";
       const localServerPort = settings.localServerPort || 8008;
+      const cityName = settings.cityName || "";
 
       textToSpeak = await chrome.runtime.sendMessage({
         type: "GENERATE_RJ",
@@ -73,6 +76,7 @@ export async function generateRJIntro(
           geminiApiKey,
           localServerPort,
           currentTime,
+          cityName,
         },
       });
 
@@ -160,16 +164,21 @@ chrome.runtime.onMessage.addListener(
       // Immediately acknowledge message to prevent port collecting error on Content Script side
       sendResponse({ received: true });
 
-      announceSong(
-        sender.tab.id,
-        currentSongTitle,
-        currentSongArtist,
-        upcomingSongTitle,
-        upcomingSongArtist,
-        currentTime,
-      );
+      chrome.storage.sync.get(["cityName"], (settings) => {
+        if (sender.tab?.id) {
+          announceSong(
+            sender.tab.id,
+            currentSongTitle,
+            currentSongArtist,
+            upcomingSongTitle,
+            upcomingSongArtist,
+            currentTime,
+            settings.cityName
+          );
+        }
+      });
     } else if (message.type === "PREWARM_RJ") {
-      const { oldSongTitle, oldArtist, newSongTitle, newArtist, currentTime } =
+      const { oldSongTitle, oldArtist, newSongTitle, newArtist, currentTime, cityName } =
         message.payload;
       console.log(
         `[Pre-Warm] Received request for ${oldSongTitle} -> ${newSongTitle}`,
@@ -180,6 +189,7 @@ chrome.runtime.onMessage.addListener(
         newSongTitle,
         newArtist,
         currentTime,
+        cityName,
       );
     } else if (message.type === "OFFSCREEN_TO_CONTENT_PROXY") {
       const { tabId, message: nestedMessage } = message.payload;
@@ -208,6 +218,7 @@ function announceSong(
   upcomingSongTitle: string,
   upcomingSongArtist: string,
   currentTime: string,
+  cityName?: string,
 ) {
   if (alreadyAnnounced.has(`${currentSongTitle}:::${upcomingSongTitle}`)) {
     console.log(
@@ -223,6 +234,7 @@ function announceSong(
     upcomingSongTitle,
     upcomingSongArtist,
     currentTime,
+    cityName,
     false,
   ).then(async (response: string) => {
     console.log("Generated Intro:", response);

--- a/src/background/background.ts
+++ b/src/background/background.ts
@@ -62,7 +62,6 @@ export async function generateRJIntro(
       const modelProvider = settings.modelProvider || "gemini-api";
       const geminiApiKey = settings.geminiApiKey || "";
       const localServerPort = settings.localServerPort || 8008;
-      const cityName = settings.cityName || "";
 
       textToSpeak = await chrome.runtime.sendMessage({
         type: "GENERATE_RJ",
@@ -76,7 +75,7 @@ export async function generateRJIntro(
           geminiApiKey,
           localServerPort,
           currentTime,
-          cityName,
+          cityName: cityName || settings.cityName || "",
         },
       });
 

--- a/src/offscreen/offscreen.ts
+++ b/src/offscreen/offscreen.ts
@@ -288,7 +288,7 @@ async function generateWithGeminiAPI(data: {
 
   try {
     const response = await fetch(
-      `https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash:generateContent?key=${apiKey}`,
+      `https://generativelanguage.googleapis.com/v1beta/models/gemini-3.5-flash:generateContent?key=${apiKey}`,
       {
         method: "POST",
         headers: {

--- a/src/offscreen/offscreen.ts
+++ b/src/offscreen/offscreen.ts
@@ -239,6 +239,7 @@ async function generateWithGeminiAPI(data: {
   newArtist: string;
   geminiApiKey?: string;
   currentTime?: string;
+  cityName?: string;
 }): Promise<string> {
   const apiKey = data.geminiApiKey;
   if (!apiKey) {
@@ -249,40 +250,51 @@ async function generateWithGeminiAPI(data: {
   const timeContext = data.currentTime
     ? ` Current time: ${data.currentTime}.`
     : "";
-  // Random 1/3 chance to add witty fact
-  const aRandomNumber = Math.random();
-  const addWittyFact = Math.floor(aRandomNumber * 3) + 1 === 3;
-  const addWeatherInfo = Math.floor(aRandomNumber * 5) + 1 === 5; // 1/5 chance to add weather info
-  const addNewsInfo = Math.floor(aRandomNumber * 10) + 1 === 10; // 1/10 chance to add news info
+  // Random chances
+  const addWittyFact = Math.random() < 1/3;
+  const addWeatherInfo = Math.random() < 1/8; // 1/8 chance to add weather info
+  const addNewsInfo = Math.random() < 1/10; // 1/10 chance to add news info
 
-  const extraInstruction = addWittyFact
-    ? "Maybe provide a witty random fact."
+  let extraInstruction = addWittyFact
+    ? "Maybe provide a witty random fact. "
     : "";
+  if (addWeatherInfo && data.cityName) {
+    extraInstruction += `Also briefly mention the current weather in ${data.cityName}. `;
+  }
+  if (addNewsInfo) {
+    extraInstruction += "Also briefly mention one piece of current international news. ";
+  }
 
-  const prompt = `Previous Song: "${data.oldSongTitle}" by "${data.oldArtist}"\nNext Song: "${data.newSongTitle}" by "${data.newArtist}"\n${timeContext}\n\nGenerate the DJ intro now.${extraInstruction}`;
+  const prompt = `Previous Song: "${data.oldSongTitle}" by "${data.oldArtist}"\nNext Song: "${data.newSongTitle}" by "${data.newArtist}"\n${timeContext}\n\nGenerate the DJ intro now. ${extraInstruction}`;
+
+  const requestBody: any = {
+    system_instruction: {
+      parts: [{ text: RJ_SYSTEM_PROMPT }],
+    },
+    contents: [
+      {
+        parts: [
+          {
+            text: prompt,
+          },
+        ],
+      },
+    ],
+  };
+
+  if (addWeatherInfo || addNewsInfo) {
+    requestBody.tools = [{ googleSearch: {} }];
+  }
 
   try {
     const response = await fetch(
-      `https://generativelanguage.googleapis.com/v1beta/models/gemini-3.5-flash:generateContent?key=${apiKey}`,
+      `https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash:generateContent?key=${apiKey}`,
       {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
         },
-        body: JSON.stringify({
-          system_instruction: {
-            parts: [{ text: RJ_SYSTEM_PROMPT }],
-          },
-          contents: [
-            {
-              parts: [
-                {
-                  text: prompt,
-                },
-              ],
-            },
-          ],
-        }),
+        body: JSON.stringify(requestBody),
       },
     );
 

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -42,6 +42,11 @@
     </div>
 
     <div class="control-group column">
+      <label for="cityNameInput">City Name (Optional - For Weather info)</label>
+      <input type="text" id="cityNameInput" placeholder="Enter City Name">
+    </div>
+
+    <div class="control-group column">
       <label for="speechSelect">Speech Service</label>
       <select id="speechSelect">
         <option value="tts">Chrome TTS</option>

--- a/src/popup/popup.ts
+++ b/src/popup/popup.ts
@@ -8,19 +8,21 @@ const localServerConfig = document.getElementById('localServerConfig') as HTMLEl
 const geminiApiConfig = document.getElementById('geminiApiConfig') as HTMLElement;
 const geminiApiKeyInput = document.getElementById('geminiApiKeyInput') as HTMLInputElement;
 const portInput = document.getElementById('portInput') as HTMLInputElement;
+const cityNameInput = document.getElementById('cityNameInput') as HTMLInputElement;
 const testConnectionBtn = document.getElementById('testConnectionBtn') as HTMLButtonElement;
 const connectionStatus = document.getElementById('connectionStatus') as HTMLElement;
 const statusText = document.getElementById('statusText') as HTMLElement;
 
 
 // Initialize state
-chrome.storage.sync.get(['isEnabled', 'isDebugEnabled', 'modelProvider', 'speechProvider', 'localServerPort', 'geminiApiKey'], (result: Partial<StorageSchema>) => {
+chrome.storage.sync.get(['isEnabled', 'isDebugEnabled', 'modelProvider', 'speechProvider', 'localServerPort', 'geminiApiKey', 'cityName'], (result: Partial<StorageSchema>) => {
     const isEnabled = result.isEnabled ?? true;
     const isDebugEnabled = result.isDebugEnabled ?? false;
     const modelProvider = result.modelProvider || 'gemini-api';
     const speechProvider = result.speechProvider || 'tts';
     const localServerPort = result.localServerPort || 8008;
     const geminiApiKey = result.geminiApiKey || '';
+    const cityName = result.cityName || '';
 
     updateUI(isEnabled, isDebugEnabled);
     
@@ -29,6 +31,7 @@ chrome.storage.sync.get(['isEnabled', 'isDebugEnabled', 'modelProvider', 'speech
     speechSelect.value = speechProvider;
     portInput.value = localServerPort.toString();
     geminiApiKeyInput.value = geminiApiKey;
+    cityNameInput.value = cityName;
 
     updateVisibility();
 });
@@ -69,6 +72,11 @@ portInput.addEventListener('change', () => {
 geminiApiKeyInput.addEventListener('change', () => {
     const geminiApiKey = geminiApiKeyInput.value;
     chrome.storage.sync.set({ geminiApiKey });
+});
+
+cityNameInput.addEventListener('change', () => {
+    const cityName = cityNameInput.value;
+    chrome.storage.sync.set({ cityName });
 });
 
 testConnectionBtn.addEventListener('click', async () => {

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -5,6 +5,7 @@ export interface StorageSchema {
   geminiApiKey?: string;
   speechProvider: "tts" | "localserver" | "gemini-api" | "kokoro";
   localServerPort: number;
+  cityName?: string;
 }
 
 export type MessageSchema =
@@ -30,6 +31,7 @@ export type MessageSchema =
         localServerPort?: number;
         systemPrompt?: string;
         currentTime?: string;
+        cityName?: string;
       };
     }
   | {
@@ -49,6 +51,7 @@ export type MessageSchema =
         modelProvider?: "gemini" | "gemini-api" | "webllm" | "localserver"; // Add this here too
         geminiApiKey?: string;
         currentTime?: string;
+        cityName?: string;
       };
     }
   | {

--- a/test_gemini.js
+++ b/test_gemini.js
@@ -1,1 +1,0 @@
-const apiKey = process.env.GEMINI_API_KEY; // if we had one

--- a/test_gemini.js
+++ b/test_gemini.js
@@ -1,0 +1,1 @@
+const apiKey = process.env.GEMINI_API_KEY; // if we had one


### PR DESCRIPTION
- Added a "City Name" setting in the popup.
- Propagated the `cityName` field through the extension components down to `offscreen.ts`.
- Implemented probabilistic instructions for adding witty facts (1/3), weather (1/8), and international news (1/10).
- Dynamically add the `{ googleSearch: {} }` tool to the Gemini API prompt if weather or news conditions are met.
- Migrated the model from `gemini-3.5-flash` to `gemini-1.5-flash` for the grounding functionality.

---
*PR created automatically by Jules for task [13360572034898115275](https://jules.google.com/task/13360572034898115275) started by @WinterSoldier13*